### PR TITLE
PX-2454: adds 'Print Inches:' option to wordcount plugin

### DIFF
--- a/plugins/wordcount/lang/en.js
+++ b/plugins/wordcount/lang/en.js
@@ -5,6 +5,7 @@
 CKEDITOR.plugins.setLang('wordcount', 'en', {
     WordCount: 'Words:',
     CharCount: 'Characters:',
+    Inches: 'Print Inches (est.):',
     CharCountWithHTML: 'Characters (with HTML):',
     Paragraphs: 'Paragraphs:',
     pasteWarning: 'Content can not be pasted because it is above the allowed limit',

--- a/plugins/wordcount/plugin.js
+++ b/plugins/wordcount/plugin.js
@@ -57,6 +57,8 @@ CKEDITOR.plugins.add("wordcount", {
             showParagraphs: true,
             showWordCount: true,
             showCharCount: false,
+            showInches: false,
+            wordsPerInch: 35,
             countSpacesAsChars: false,
             countHTML: false,
             hardLimit: true,
@@ -114,6 +116,14 @@ CKEDITOR.plugins.add("wordcount", {
             if (config.maxCharCount > -1) {
                 defaultFormat += "/" + config.maxCharCount;
             }
+        }
+
+        if ((config.showCharCount || config.showWordCount) && config.showInches) {
+            defaultFormat += ", ";
+        }
+
+        if (config.showInches) {
+            defaultFormat += editor.lang.wordcount.Inches + " %inches%";
         }
 
         var format = defaultFormat;
@@ -223,6 +233,11 @@ CKEDITOR.plugins.add("wordcount", {
             return (words.length);
         }
 
+        function countInches(text) {
+            var inches = countWords(text) / config.wordsPerInch;
+            return Math.round(inches * 10) / 10;
+        }
+
         function limitReached(editorInstance, notify) {
             limitReachedNotified = true;
             limitRestoredNotified = false;
@@ -252,6 +267,7 @@ CKEDITOR.plugins.add("wordcount", {
             var paragraphs = 0,
                 wordCount = 0,
                 charCount = 0,
+                inches = 0,
                 text;
 
             if (text = editorInstance.getData()) {
@@ -266,9 +282,13 @@ CKEDITOR.plugins.add("wordcount", {
                 if (config.showWordCount) {
                     wordCount = countWords(text);
                 }
+
+                if (config.showInches) {
+                    inches = countInches(text);
+                }
             }
 
-            var html = format.replace("%wordCount%", wordCount).replace("%charCount%", charCount).replace("%paragraphs%", paragraphs);
+            var html = format.replace("%wordCount%", wordCount).replace("%charCount%", charCount).replace("%paragraphs%", paragraphs).replace("%inches%", inches);
 
             (editorInstance.config.wordcount || (editorInstance.config.wordcount = {})).wordCount = wordCount;
             (editorInstance.config.wordcount || (editorInstance.config.wordcount = {})).charCount = charCount;


### PR DESCRIPTION
# [PX-2454](https://jira.gannett.com/browse/PX-2454) Add Print Inches to CKEditor wordcount plugin

> Add a "print inches" display option to the wordcount plugin for CKEditor.
## AC
- [x] Configuration options of `showInches` and `wordsPerInch`.
- [x] Label text: "Print Inches (est.):"
- [x] Insert inch count after character count.
## Screenshot

![inchcount](https://cloud.githubusercontent.com/assets/777546/18793740/c6c55970-8181-11e6-952d-cce99eddff8f.png)
