### PR TITLE
CSAUTH-918 - CQ Text should not appear in story displays

### DIFF
--- a/plugins/copycheck/plugin.js
+++ b/plugins/copycheck/plugin.js
@@ -16,7 +16,7 @@
             var cqImage = this.path + 'icons/CopyCheckReverse.png';
             editor.addCommand('insertCQ', {
                 exec: function (editor) {
-                    editor.insertHtml('<img class="notes" title="Copy checked" src="' + cqImage + '">');
+                    editor.insertHtml('<img class="notes px-cq" title="Copy checked" src="' + cqImage + '">');
                 }
             });
 


### PR DESCRIPTION
libgeronimo expects CQ images to contain both `notes` and `px-cq` classes and strips them out.