### PR TITLE
CSAUTH 1886 - Remove MarkAsNotes from the wordcount figures

### DIFF
--- a/plugins/wordcount/plugin.js
+++ b/plugins/wordcount/plugin.js
@@ -151,6 +151,12 @@ CKEDITOR.plugins.add("wordcount", {
                     assetCard.remove();
                 }
             });
+
+            var markAsNotesTexts = tmp.querySelectorAll('.notes');
+
+            markAsNotesTexts.forEach(function(note) {
+                note.remove();
+            })
             // END: Presto edge-case
 
             if (tmp.textContent == "" && typeof tmp.innerText == "undefined") {


### PR DESCRIPTION
JIRA Story: https://jira.gannett.com/browse/CSAUTH-1886

Changes:
- Check for text elements that are "Mark As Notes" elem and remove them from the word count.

Before (notice word count on the bottom right)
<img width="1061" alt="screen shot 2017-04-28 at 2 37 58 pm" src="https://cloud.githubusercontent.com/assets/4501479/25542426/909044e2-2c20-11e7-9b33-84c9c95ab818.png">
After (the word count is lower)
<img width="997" alt="screen shot 2017-04-28 at 2 38 07 pm" src="https://cloud.githubusercontent.com/assets/4501479/25542429/95defd12-2c20-11e7-9525-17d74170de3f.png">
