### PR TITLE
CE-419 - Adding access to printInches (inches) in global namespace

### DIFF
--- a/plugins/wordcount/plugin.js
+++ b/plugins/wordcount/plugin.js
@@ -304,6 +304,7 @@ CKEDITOR.plugins.add("wordcount", {
 
             (editorInstance.config.wordcount || (editorInstance.config.wordcount = {})).wordCount = wordCount;
             (editorInstance.config.wordcount || (editorInstance.config.wordcount = {})).charCount = charCount;
+            (editorInstance.config.wordcount || (editorInstance.config.wordcount = {})).printInches = inches;
 
             if (CKEDITOR.env.gecko) {
                 counterElement(editorInstance).innerHTML = html;


### PR DESCRIPTION
# [CE-419](https://jira.gannett.com/browse/CE-419): Presto needs to save character count and print inches

#### Description:
With the work in CE-244, data for characterCount, wordCount and printInches is added to libgeronimo.  
Now work needs to be done for Presto to send that information with the story to geronimo.

A/C

- printInches needs to be returned like wordCount and charCount are currently.
