### PR TITLE
CE-3401:- As a Presto user in the field, I need to be able to view more of my story body at once.

### DIFF
--- a/plugins/collapse/css/collapse.css
+++ b/plugins/collapse/css/collapse.css
@@ -1,0 +1,18 @@
+
+#cke_storyeditor .cke_top .cke_button__collapse.cke_button_off,
+#cke_storyeditor .cke_top .cke_button__collapse.cke_button_on,
+#cke_storyeditor .cke_top .cke_button__collapse.cke_button_off:focus,
+#cke_storyeditor .cke_top .cke_button__collapse.cke_button_off:active
+{
+    border:none;
+    background: transparent;
+}
+
+.cke_button__collapse.cke_button_on .cke_button__collapse_icon:after {
+    content: '\f078';
+    font-family: 'FontAwesome';
+}
+.cke_button__collapse.cke_button_off .cke_button__collapse_icon:after {
+    content: '\f077';
+    font-family: 'FontAwesome';
+}

--- a/plugins/collapse/plugin.js
+++ b/plugins/collapse/plugin.js
@@ -1,0 +1,65 @@
+(function () {
+    CKEDITOR.plugins.add('Collapse', {
+
+        afterInit: function () {
+            var collapseButton = document.querySelector('.cke_button__collapse');
+            if (collapseButton) {
+                if (window.innerWidth <= 768) {
+                    var collapseToolbox = collapseButton.parentElement;
+                    collapseToolbox.style.background = 'transparent';
+                    collapseToolbox.style.border = 'none';
+
+                    var collapseToolbar = collapseToolbox.parentElement;
+                    collapseToolbar.style.cssFloat = 'right';
+                    const newlineElement = document.createElement('br');
+                    newlineElement.style.lineHeight = '33px';
+                    collapseToolbar.parentElement.insertBefore(newlineElement, collapseToolbar.nextSibling);
+                }
+                else {
+                    collapseButton.parentElement.parentElement.remove();
+                }
+            }
+        },
+        onLoad: function () {
+            CKEDITOR.document.appendStyleSheet(this.path + "css/collapse.css");
+        },
+        init: function (editor) {
+            function modifyPlugins (displayStyle) {
+                var collapseIndex = editor.toolbox.toolbars.length;
+                for (var toolbarIndex = 0; toolbarIndex < editor.toolbox.toolbars.length; toolbarIndex++) {
+                    var toolbar = editor.toolbox.toolbars[ toolbarIndex ];
+                    for (var itemsIndex = 0; itemsIndex < toolbar.items.length; itemsIndex++) {
+                        var item = toolbar.items[ itemsIndex ];
+                        if (item.button && item.button.command === 'Collapse') {
+                            collapseIndex = toolbarIndex + 1;
+                            break;
+                        }
+                    }
+                }
+                const toolbars = editor.toolbox.toolbars.slice(collapseIndex);
+                toolbars.forEach(({ id }) => {
+                    document.getElementById(id).style.display = displayStyle;
+                });
+            }
+
+            editor.addCommand('Collapse', {
+                exec: function (editor) {
+                    var commandState = editor.getCommand('Collapse').state;
+                    if (commandState === CKEDITOR.TRISTATE_OFF) {
+                        commandState = CKEDITOR.TRISTATE_ON;
+                        modifyPlugins('none');
+                    } else {
+                        commandState = CKEDITOR.TRISTATE_OFF;
+                        modifyPlugins('inherit');
+                    }
+                    editor.getCommand('Collapse').setState(commandState);
+                }
+            });
+            editor.ui.addButton('Collapse', {
+                label: 'Collapse Editor',
+                command: 'Collapse',
+                toolbar: 'Collapse'
+            });
+        }
+    });
+})();


### PR DESCRIPTION
This PR includes changes to add a new "Collapse plugin" with the following features:-
1. It will only be visible if the screen size is less than 768px
2. It will hide all the succeeding plugins from its position when the collapse button is clicked.
3. When collapse is turned off, all the succeeding plugins will be present in a new line.

![collapse off](https://user-images.githubusercontent.com/40604484/54832152-a1f43700-4ce1-11e9-8810-9cc26f756e91.png)

![Collapse on](https://user-images.githubusercontent.com/40604484/54832155-a1f43700-4ce1-11e9-846a-6865343dbdf5.png)

